### PR TITLE
adding links to documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,11 @@ html:
 	docco litsynth.js.md
 
 gh-page: html
+	cp ./clap.ogg ./docs
+	cp ./demo.html ./docs
+	cp ./litsynth.js ./docs
 	git checkout gh-pages
 	rm -f litsynth.js.md LICENSE README.md Makefile
-	mv docs/* .
+	cp -r ./docs/* . && rm -R ./docs/*
 	rmdir docs
 	mv litsynth.js.html index.html

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ litsynth
 `litsynth` is a minimal synth for demoscene purposes, written in literate
 javascript, using the Web Audio API.
 
+Links
+=====
+
+- [Source Code](https://github.com/padenot/litsynth)
+- [Documentation](http://padenot.github.io/litsynth/index.html)
+- [Demonstration](http://padenot.github.io/litsynth/demo.html)
+
 License
 =======
 

--- a/litsynth.js.md
+++ b/litsynth.js.md
@@ -1,6 +1,10 @@
 litsynth
 =========
 
+- [Source Code](https://github.com/padenot/litsynth)
+- [Documentation](http://padenot.github.io/litsynth/index.html)
+- [Demonstration](http://padenot.github.io/litsynth/demo.html)
+
 Introduction and scope
 ----------------------
 


### PR DESCRIPTION
Updating gh-pages branch with some links.  You can check out my fork, but you'll have to replace padenot with skratchdot for the links to work.  If you pull this in, it'll work in your repo.

It'll make it easier for people to view the demo and find your github page.

Must pull in `gh-pages` branch pull request, then the `master` branch pull request.
