### PR TITLE
Start demo with a button press

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,1 +1,2 @@
+<button id="start">Start</button>
 <script src=litsynth.js></script>

--- a/litsynth.js
+++ b/litsynth.js
@@ -153,12 +153,14 @@ var track = {
            36,60,36, 0,39, 0,48, 0 ]
   }
 };
-fetch('clap.ogg').then((response) => {
-  response.arrayBuffer().then((arraybuffer) => {
-    var ac = new AudioContext();
-    ac.decodeAudioData(arraybuffer).then((clap) => {
-      var s = new S(ac, clap, track);
-      s.start();
+document.getElementById('start')?.addEventListener('click', function() {
+  fetch('clap.ogg').then((response) => {
+    response.arrayBuffer().then((arraybuffer) => {
+      var ac = new AudioContext();
+      ac.decodeAudioData(arraybuffer).then((clap) => {
+        var s = new S(ac, clap, track);
+        s.start();
+      });
     });
   });
-});
+}, {once: true});

--- a/litsynth.js.md
+++ b/litsynth.js.md
@@ -426,15 +426,17 @@ a playlist instead of directly the notes, so that patterns can be reused.
     };
 
 Finally, we get an AudioContext, pass it to the synth along with a track, and
-start the tune.
+start the tune. We have to do this in response to a user action due to
+[autoplaying audio being disallowed](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Autoplay).
 
-
-    fetch('clap.ogg').then((response) => {
-      response.arrayBuffer().then((arraybuffer) => {
-        var ac = new AudioContext();
-        ac.decodeAudioData(arraybuffer).then((clap) => {
-          var s = new S(ac, clap, track);
-          s.start();
+    document.getElementById('start')?.addEventListener('click', function() {
+      fetch('clap.ogg').then((response) => {
+        response.arrayBuffer().then((arraybuffer) => {
+          var ac = new AudioContext();
+          ac.decodeAudioData(arraybuffer).then((clap) => {
+            var s = new S(ac, clap, track);
+            s.start();
+          });
         });
       });
-    });
+    }, {once: true});


### PR DESCRIPTION
Since this demo was created, browsers have started blocking autoplaying audio. Work around this by adding a "Start" button and starting the final portion of the demo in response to a click.

Tested with:

```
make js
python -m http.server
```

Verified that it works with this local server.

(Thank you for the super fun demo! Love how it sounds.)